### PR TITLE
Add README, project metadata, and other configs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+
+[*.bat]
+indent_style = tab
+end_of_line = crlf
+
+[LICENSE]
+insert_final_newline = false
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+* fact-species-viz version:
+* Python version:
+* Operating System:
+
+### Description
+
+Describe what you were trying to get done.
+Tell us what happened, what went wrong, and what you expected to happen.
+
+### What I Did
+
+```
+Paste the command(s) you ran and the output.
+If there was a crash, please include the traceback here.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,144 @@
 out/*
 cache/*
 data/*.csv
-__pycache__
 .envrc
-.mypy_cache
 .vscode
 node_modules
-.cache
-dist
 tmp
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# vim
+*.swp
+
+# Generated dynamically
+fact_species_viz/_version.py
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,68 @@
+repos:
+
+- repo: https://github.com/econchick/interrogate
+  rev: 1.5.0
+  hooks:
+    - id: interrogate
+      # https://github.com/pre-commit/pre-commit/issues/2122
+      additional_dependencies: [setuptools]
+      exclude: ^(docs|tests)
+      args: [--config=pyproject.toml]
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+    - id: trailing-whitespace
+      exclude: tests/data
+    - id: check-ast
+    - id: debug-statements
+    - id: end-of-file-fixer
+    - id: check-docstring-first
+    - id: check-added-large-files
+    - id: requirements-txt-fixer
+    - id: file-contents-sorter
+      files: requirements-dev.txt
+
+- repo: https://github.com/pycqa/flake8
+  rev: 6.1.0
+  hooks:
+    - id: flake8
+      exclude: docs
+      args: [--max-line-length=105 ]
+
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v5.10.1
+  hooks:
+  - id: isort
+    additional_dependencies: [toml]
+    exclude: ^(docs)
+    args: [--project=gcm_filters, --multi-line=3, --lines-after-imports=2, --lines-between-types=1, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=88]
+
+- repo: https://github.com/asottile/seed-isort-config
+  rev: v2.2.0
+  hooks:
+    - id: seed-isort-config
+
+- repo: https://github.com/psf/black
+  rev: 22.10.0
+  hooks:
+  - id: black
+    exclude: ^(docs)
+    language_version: python3
+    line_length: 105
+
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.13.0
+  hooks:
+  - id: mypy
+    additional_dependencies: [types-setuptools, types-requests]
+    exclude: docs
+    args: [--ignore-missing-imports]
+
+# - repo: https://github.com/codespell-project/codespell
+#   rev: v1.16.0
+#   hooks:
+#     - id: codespell
+#       args:
+#         - --quiet-level=2

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,14 @@
+=======
+Credits
+=======
+
+Development Lead
+----------------
+
+* Dave Foster <dev@axiomdatascience.com>
+
+Contributors
+------------
+
+* Shane St Savage <shane@axiomdatascience.com>
+* Honza Rychly <honza@axiomdatascience.com>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,50 @@
+.. highlight:: shell
+
+============
+Contributing
+============
+
+Contributions are welcome, and they are greatly appreciated! Every little bit
+helps, and credit will always be given.
+
+You can contribute in many ways:
+
+Types of Contributions
+----------------------
+
+Report Bugs
+~~~~~~~~~~~
+Report bugs at https://github.com/dev/fact-species-viz/issues.
+If you are reporting a bug, please include:
+
+* Your operating system name and version.
+* Any details about your local setup that might be helpful in troubleshooting.
+* Detailed steps to reproduce the bug.
+
+Fix Bugs
+~~~~~~~~
+
+Look through the GitHub issues for bugs. Anything tagged with "bug" and "help
+wanted" is open to whoever wants to implement it.
+
+Implement Features
+~~~~~~~~~~~~~~~~~~
+
+Look through the GitHub issues for features. Anything tagged with "enhancement"
+and "help wanted" is open to whoever wants to implement it.
+
+Write Documentation
+~~~~~~~~~~~~~~~~~~~
+
+fact-species-viz could always use more documentation, whether as part of the
+official fact-species-viz docs, in docstrings, or even on the web in blog posts,
+articles, and such.
+
+Submit Feedback
+~~~~~~~~~~~~~~~
+The best way to send feedback is to file an issue at https://github.com/dev/fact-species-viz/issues.If you are proposing a feature:
+
+* Explain in detail how it would work.
+* Keep the scope as narrow as possible, to make it easier to implement.
+* Remember that this is a volunteer-driven project, and that contributions
+  are welcome :)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:12.13 AS build
+LABEL org.opencontainers.image.authors="Developer <dev@axiomdatascience.com>"
+LABEL org.opencontainers.image.licenses="MIT"
+
 RUN mkdir /tmp/build
 WORKDIR /tmp/build
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025, Axiom Data Science, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+.PHONY: clean clean-build clean-pyc clean-test coverage help install lint lint/flake8 lint/black lint/isort format format/black format/isort test test-all
+.DEFAULT_GOAL := help
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+	rm -fr .pytest_cache
+
+lint/flake8: ## check style with flake8
+	flake8 scripts tests
+
+lint/black: ## check style with black
+	black --check scripts tests
+
+lint/isort: ## check imports style
+	isort --check-only scripts tests
+
+lint: lint/flake8 lint/black ## check style
+
+format/black: ## format code with black
+	black scripts tests
+
+format/isort: ## format imports
+	isort scripts tests
+
+format: format/black format/isort lint/flake8 ## format code
+
+test: ## run tests quickly with the default Python
+	pytest
+
+test-all: ## run tests on every Python version with tox
+	tox
+
+coverage: ## check code coverage quickly with the default Python
+	pytest --cov=./ --cov-report html:cov_html -sv
+	$(BROWSER) ./cov_html/index.html
+
+install:
+	conda env create --file environment.yml

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,185 @@
+
+
+FACT DaViT
+===============================
+
+This project is a data visualization tool for the Florida Atlantic Coast Telemetry (FACT) network.
+It includes both backend and frontend components for fetching, processing, and visualizing species data.
+
+The FACT DaViT (Data Visualization Tool) displays animal movement metrics.
+Using acoustic telemetry data from the FACT Network (southeastern US, with global collaboration through OTN),
+this tool shows range and distribution on a map for a number of studied species
+within the FACT Network's members.
+
+A live deployment: https://secoora.org/fact/data-visualization-tool/
+
+Copyright 2025 Axiom Data Science, LLC
+
+See LICENSE for details.
+
+
+What is acoustic telemetry?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Acoustic telemetry uses sound to transmit information underwater.
+An animal is tagged with an acoustic transmitter which emits a sounds that
+is understood and decoded by a receiver which is submerged underwater in a fixed location.
+The receiver logs the unique ID, date, and time of when the animal was within
+the listening range of the receiver. See https://secoora.org/fact/acoustic-telemetry/
+for more information.
+
+Project structure
+-----------------
+
+Unforunately, the frontend and backend projects are overlaid on top of each other
+in the root of the repository. This means that there are Python and Node.js configuration
+files mixed together. The Python source code for the backend is in the ``scripts``
+directory, and the frontend JavaScript source code is in the ``src`` directory with HTML in ``static``.
+
+Python project installation
+---------------------------
+
+The backend Python project relies on conda for installation and managing of the project dependencies.
+
+1. Download and install miniconda for your operating system https://docs.conda.io/en/latest/miniconda.html.
+
+2. Clone this project with ``git``.
+
+3. Once conda is available build the environment for this project with::
+
+      conda env create -f environment.yml
+
+   The above command creates a new conda environment titled ``fact-species-viz`` with the necessary project
+   dependencies.
+
+4. An Additional environment file is present for testing and development environments. The additional developer dependencies can be installed with::
+
+      conda env update -f dev-environment.yml
+
+5. To install the project to the new environment::
+
+      conda activate fact-species-viz
+      pip install -e .
+
+There is also a ``modd.conf`` file for development  with `modd <https://github.com/cortesi/modd>`_.
+
+Running Tests
+-------------
+
+To run the Python project's tests::
+
+      make test
+
+or run pytest directly::
+
+      pytest
+
+To run Python project linting and formatting checks::
+
+      make lint # only check
+      make format # fixes formatting and checks with flake8
+      pre-commit run --all-files # runs a comprehensive analysis
+
+Building with Docker
+--------------------
+
+To build the docker containers::
+
+      docker build -t davit-api . --file Dockerfile.backend
+      docker build -t davit-ui .
+
+Running with Docker
+-------------------
+To start the backend stack using the docker compose file::
+
+      docker compose up -d
+
+To start the frontend server::
+
+      docker run \
+            -p 47001:80 \
+            -e DATA_URL=http://localhost:47000 \
+            -e MAPBOX_TOKEN=your-mapbox-token \
+            davit-ui
+
+Now you should be able to see the API documentation at http://localhost:47000/docs
+and Flower task monitoring at http://localhost:45555.
+
+The fontend application should be available at http://localhost:47001.
+
+About and History
+-----------------
+
+Dave Foster built both the backend service and front end application during 2021/2022
+at Axiom Data Sciene.
+
+Later this project was made open source and published here on GitHub.
+
+Backend
+^^^^^^^
+
+The ``fact-species-viz`` project started as a command line processing tool to take “raw” detection
+extracts data from acoustic telemetry research and transform them into geojson products
+representing range and distribution of species. These geojson files can be shown on a map.
+
+The backend has since evolved into a small API that can perform the required processing
+for any approved unit of data via a Celery queue and workers.
+While the end product is geojson files and is intended to possibly not need a service
+(just serve the geojson files, along with some sort of inventory file cataloging the contents
+of the geojson files), there is a service that stores both the geojson files as well as
+inventory and metadata in a private Redis instance.
+
+The backend is written in Python and uses FastAPI/uvicorn for async API access,
+Celery for queuing of jobs, and geopandas for data processing/manipulation.
+
+Frontend
+^^^^^^^^
+
+The frontend portion started as a React application with ``react-map-gl`` (``mapbox-gl`` based)
+at its core to display the computed geojson files.
+
+The frontend application allows users to see the available species and research projects
+contributing to the species products along with comparison tools via layering
+(z-index w/ opacity) and hover interrogation.
+
+The application is designed to direct you toward contacting specific researchers by
+including citations and metadata about the data shown.
+
+The frontend is able to save current user state via the browser's localStorage feature,
+allowing resuming of a session by the same browser.
+
+Data
+^^^^
+
+The FACT DaViT frontend and backend produce no unique data.
+The geojson files and metadata are produced via computation by the backend service
+and can be recomputed at any time from source data. The source data is pulled via API access
+to the `Research Workspace <https://researchworkspace.com/intro/>`_ over several projects.
+This source data is called “Detection Extracts”
+and consist of zipped CSV files which are generated by the FACT Network and OTN three times
+a year (known as a “data push” - when researchers send their raw data in, this raw data is
+cleaned and aligned with other researchers data for a more complete picture).
+
+When requested, the backend service will enqueue and execute processing of data by project.
+Projects available in the DaViT are opt-in, meaning folks involved in the research must approve
+their projects to be added. This is managed by FACT with the help of a form
+at https://secoora.org/fact/davit-agreement/ | http://git.axiom/axiom/fact-agreement.
+Joy Young (FACT leader) keeps a list of approved projects.
+A single endpoint can be POSTed to in order to regenerate all data.
+
+While the source data is stored by project, the geojson products are primarily by species.
+Many projects that research the same species contribute to the geojson products.
+This contribution happens automatically in the backend when more than one project
+has the same species, no matter when it's been processed.
+
+Data processing has two rounds: first by project code, then the “ALL” layer.
+The “ALL” layer must be done separately because it has to happen after all project codes
+have been finished.
+
+Credits
+-------
+
+This package was updated with Cookiecutter_ and the `audreyr/cookiecutter-pypackage`_ project template.
+
+.. _Cookiecutter: https://github.com/audreyr/cookiecutter
+.. _`audreyr/cookiecutter-pypackage`: https://github.com/audreyr/cookiecutter-pypackage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  behavior: default

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Pytest configuration."""
+
+import pytest
+
+
+def pytest_addoption(parser):
+    """Adds --integration option to pytest."""
+    parser.addoption(
+        "--integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests.",
+    )
+
+
+def pytest_configure(config):
+    """Adds marker for slow."""
+    config.addinivalue_line("markers", "integration: mark test as an integration test")
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skips tests marked slow if --integration isn't used."""
+    if config.getoption("--integration"):
+        return
+    skip_integration = pytest.mark.skip(reason="need --integration option to run")
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,0 +1,13 @@
+name: fact-species-viz
+channels:
+  - conda-forge
+dependencies:
+  - pytest
+  - pytest-cov
+  - isort
+  - flake8
+  - black
+  - pre-commit
+  - types-setuptools
+  - mypy
+  - bump2version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,71 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fact-species-viz"
+version = "1.0.0"
+description = "Data visualization tool for the Florida Atlantic Coast Telemetry"
+authors = [
+    {name = "Developer", email="dev@axiomdatascience.com"},
+]
+readme = {file = "README.rst", content-type="text/x-rst"}
+license = {file = "LICENSE"}
+keywords = ["fact-species-viz", "FACT", "DaViT"]
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.9.18"
+]
+
+[project.urls]
+
+
+[tool.interrogate]
+ignore-init-method = true
+ignore-init-module = false
+ignore-magic = false
+ignore-semiprivate = true
+ignore-private = true
+ignore-property-decorators = true
+ignore-module = false
+fail-under = 95
+exclude = ["docs", "tests"]
+verbose = 1
+quiet = false
+color = true
+
+[tool.black]
+exclude = "tests/fixtures/*"
+line-length = 105
+
+[tool.isort]
+profile = "black"
+skip_glob = ["docs/*", "docs/**/*.py"]
+line_length = 105
+known_third_party = ["celery", "click", "environs", "fastapi", "geojson", "geopandas", "jinjasql", "numpy", "orjson", "pandas", "process", "pydantic", "pydantic_settings", "pyproj", "pytest", "pyvisgraph", "redis", "requests", "scipy", "shapely", "shapely_geojson", "skimage", "sqlalchemy", "tqdm"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-v"
+# only test the root level, otherwise it picks up the tests of the project template
+testpaths = [
+    "tests",
+]
+
+[tool.coverage.run]
+omit = [
+    "fact_species_viz/_version.py",
+    "fact_species_viz/version.py",
+    "tests/*",
+]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-dir]
+fact_species_viz = "fact_species_viz"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for fact-species-viz Python backend."""
+
+__author__ = """Dave Foster"""
+__email__ = "dev@axiomdatascience.com"
+__version__ = "1.0.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,25 @@
+[bumpversion]
+current_version = 1.0.0
+commit = True
+tag = True
+
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+
+[bumpversion:file:scripts/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bdist_wheel]
+universal = 1
+
+[flake8]
+max-line-length = 105
+extend-ignore = E203,E701
+exclude =
+    tests/fixtures/*
+    docs
+
+[tool:pytest]
+collect_ignore = ['setup.py']

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Unit test package for fact-species-viz."""

--- a/tests/test_fact_species_viz.py
+++ b/tests/test_fact_species_viz.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+"""Tests for `fact_species_viz` package."""
+
+import pytest
+
+
+@pytest.fixture
+def example_data() -> str:
+    return "hi"
+
+
+def test_content(example_data):
+    """Sample pytest test function with the pytest fixture as an argument."""
+    assert example_data == "hi"


### PR DESCRIPTION
Changes:
- compiling a README
- adding linting, formatting, and other configuration files from a cookiecutter project template
- adding a LICENSE and other project metadata files
- adding installation and execution instructions based on existing Docker files, the GitLab CI config, and experimentation